### PR TITLE
Add volume levelbar inline

### DIFF
--- a/data/indicator.css
+++ b/data/indicator.css
@@ -3,6 +3,27 @@
  * SPDX-FileCopyrightText: 2019-2023 elementary, Inc. (https://elementary.io)
  */
 
+.composited-indicator levelbar.horizontal block {
+   min-height: 4px;
+}
+
+.composited-indicator levelbar.horizontal trough {
+    box-shadow:
+        0 0 2px alpha(black, 0.3),
+        0 1px 2px alpha(black, 0.6);
+    min-width: 64px;
+}
+
+.composited-indicator levelbar block.filled {
+    background: white;
+}
+
+.composited-indicator levelbar block {
+    background: alpha(white, 0.35);
+    border: none;
+    box-shadow: none;
+}
+
 .mic-icon {
     animation: none;
     min-width: 24px;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -154,6 +154,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
         if (volume != volume_scale.scale_widget.get_value ()) {
             volume_scale.scale_widget.set_value (volume);
             display_widget.icon_name = get_volume_icon (volume);
+            display_widget.volume = volume;
         }
     }
 


### PR DESCRIPTION
Alternative design solution for #13. Instead of showing volume change confirmations as a notification, temporarily show an inline levelbar.

![Screenshot from 2023-12-29 12 43 19](https://github.com/elementary/wingpanel-indicator-sound/assets/7277719/90b54b0f-cd74-4e59-8cc2-c6877e510614)

This is just a proof of concept. Todo:
- [ ] Support levelbars in the panel's css so we're not duplicating styles
- [ ] Don't show the levelbar when the panel first starts
- [ ] hide the levelbar when the indicator is open
- [ ] Don't show the levelbar when sound is changed via system settings
- [ ] Don't show volume change confirmations as a notification
- [ ] handle mic volume changes?
- [ ] volume blocking styles?
- [ ] insensitive style for mute?
- [ ] stay revealed when hovered?
- [ ] Test screen reader behavior