### PR TITLE
Fix build failing when defining signals with Gdk.ScrollEvent

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -328,16 +328,16 @@ public class Sound.Indicator : Wingpanel.Indicator {
         display_widget.icon_name = get_volume_icon (volume_control.volume.volume);
     }
 
-    private void on_volume_icon_scroll_event (Value event_boxed) {
-        unowned var e = (Gdk.ScrollEvent) event_boxed.peek_pointer ();
+    private void on_volume_icon_scroll_event (Value event_value) {
+        unowned var e = (Gdk.ScrollEvent) event_value.peek_pointer ();
         double dir = 0.0;
         if (handle_scroll_event (e, out dir)) {
             handle_change (dir, false);
         }
     }
 
-    private void on_mic_icon_scroll_event (Value event_boxed) {
-        unowned var e = (Gdk.ScrollEvent) event_boxed.peek_pointer ();
+    private void on_mic_icon_scroll_event (Value event_value) {
+        unowned var e = (Gdk.ScrollEvent) event_value.peek_pointer ();
         double dir = 0.0;
         if (handle_scroll_event (e, out dir)) {
             handle_change (dir, true);
@@ -422,8 +422,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
                 volume_control.mic_volume = mic_adjustment.get_value ();
             });
 
-            mic_scale.scroll_event.connect_after ((event_boxed) => {
-                unowned var e = (Gdk.ScrollEvent) event_boxed.peek_pointer ();
+            mic_scale.scroll_event.connect_after ((event_value) => {
+                unowned var e = (Gdk.ScrollEvent) event_value.peek_pointer ();
                 double dir = 0.0;
                 if (handle_scroll_event (e, out dir)) {
                     handle_change (dir, true);
@@ -446,8 +446,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
             volume_scale.slider_dropped.connect (play_volume_change_sound);
 
-            volume_scale.scroll_event.connect_after ((event_boxed) => {
-                unowned var e = (Gdk.ScrollEvent) event_boxed.peek_pointer ();
+            volume_scale.scroll_event.connect_after ((event_value) => {
+                unowned var e = (Gdk.ScrollEvent) event_value.peek_pointer ();
                 double dir = 0.0;
                 if (handle_scroll_event (e, out dir)) {
                     handle_change (dir, false);

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -329,7 +329,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
     }
 
     private void on_volume_icon_scroll_event (Value event_boxed) {
-        unowned var e = (Gdk.ScrollEvent) event_boxed.get_boxed ();
+        unowned var e = (Gdk.ScrollEvent) event_boxed.peek_pointer ();
         double dir = 0.0;
         if (handle_scroll_event (e, out dir)) {
             handle_change (dir, false);
@@ -337,7 +337,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
     }
 
     private void on_mic_icon_scroll_event (Value event_boxed) {
-        unowned var e = (Gdk.ScrollEvent) event_boxed.get_boxed ();
+        unowned var e = (Gdk.ScrollEvent) event_boxed.peek_pointer ();
         double dir = 0.0;
         if (handle_scroll_event (e, out dir)) {
             handle_change (dir, true);
@@ -423,7 +423,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
             });
 
             mic_scale.scroll_event.connect_after ((event_boxed) => {
-                unowned var e = (Gdk.ScrollEvent) event_boxed.get_boxed ();
+                unowned var e = (Gdk.ScrollEvent) event_boxed.peek_pointer ();
                 double dir = 0.0;
                 if (handle_scroll_event (e, out dir)) {
                     handle_change (dir, true);
@@ -447,7 +447,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
             volume_scale.slider_dropped.connect (play_volume_change_sound);
 
             volume_scale.scroll_event.connect_after ((event_boxed) => {
-                unowned var e = (Gdk.ScrollEvent) event_boxed.get_boxed ();
+                unowned var e = (Gdk.ScrollEvent) event_boxed.peek_pointer ();
                 double dir = 0.0;
                 if (handle_scroll_event (e, out dir)) {
                     handle_change (dir, false);

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -328,14 +328,16 @@ public class Sound.Indicator : Wingpanel.Indicator {
         display_widget.icon_name = get_volume_icon (volume_control.volume.volume);
     }
 
-    private void on_volume_icon_scroll_event (Gdk.ScrollEvent e) {
+    private void on_volume_icon_scroll_event (Value event_boxed) {
+        unowned var e = (Gdk.ScrollEvent) event_boxed.get_boxed ();
         double dir = 0.0;
         if (handle_scroll_event (e, out dir)) {
             handle_change (dir, false);
         }
     }
 
-    private void on_mic_icon_scroll_event (Gdk.ScrollEvent e) {
+    private void on_mic_icon_scroll_event (Value event_boxed) {
+        unowned var e = (Gdk.ScrollEvent) event_boxed.get_boxed ();
         double dir = 0.0;
         if (handle_scroll_event (e, out dir)) {
             handle_change (dir, true);
@@ -420,7 +422,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
                 volume_control.mic_volume = mic_adjustment.get_value ();
             });
 
-            mic_scale.scroll_event.connect_after ((e) => {
+            mic_scale.scroll_event.connect_after ((event_boxed) => {
+                unowned var e = (Gdk.ScrollEvent) event_boxed.get_boxed ();
                 double dir = 0.0;
                 if (handle_scroll_event (e, out dir)) {
                     handle_change (dir, true);
@@ -443,7 +446,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
             volume_scale.slider_dropped.connect (play_volume_change_sound);
 
-            volume_scale.scroll_event.connect_after ((e) => {
+            volume_scale.scroll_event.connect_after ((event_boxed) => {
+                unowned var e = (Gdk.ScrollEvent) event_boxed.get_boxed ();
                 double dir = 0.0;
                 if (handle_scroll_event (e, out dir)) {
                     handle_change (dir, false);

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -25,6 +25,7 @@ public class Sound.DisplayWidget : Gtk.Box {
 
     // HACK: Using Gdk.ScrollEvent instead of Value as the type of the parameter
     // resulsts build error with valac 0.56.18
+    // See https://gitlab.gnome.org/GNOME/vala/-/work_items/1671
     public signal void volume_scroll_event (Value event_value);
     public signal void mic_scroll_event (Value event_value);
 

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -53,7 +53,7 @@ public class Sound.DisplayWidget : Gtk.Box {
             }
 
             var event_boxed = Value (typeof (Gdk.ScrollEvent));
-            event_boxed.set_boxed (e);
+            event_boxed.set_instance (e);
             mic_scroll_event (event_boxed);
             return Gdk.EVENT_STOP;
         });
@@ -65,7 +65,7 @@ public class Sound.DisplayWidget : Gtk.Box {
             }
 
             var event_boxed = Value (typeof (Gdk.ScrollEvent));
-            event_boxed.set_boxed (e);
+            event_boxed.set_instance (e);
             volume_scroll_event (event_boxed);
             return Gdk.EVENT_STOP;
         });

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -25,8 +25,8 @@ public class Sound.DisplayWidget : Gtk.Box {
 
     // HACK: Using Gdk.ScrollEvent instead of Value as the type of the parameter
     // resulsts build error with valac 0.56.18
-    public signal void volume_scroll_event (Value event_boxed);
-    public signal void mic_scroll_event (Value event_boxed);
+    public signal void volume_scroll_event (Value event_value);
+    public signal void mic_scroll_event (Value event_value);
 
     construct {
         var volume_icon = new Gtk.Image () {
@@ -52,9 +52,9 @@ public class Sound.DisplayWidget : Gtk.Box {
                 return Gdk.EVENT_PROPAGATE;
             }
 
-            var event_boxed = Value (typeof (Gdk.ScrollEvent));
-            event_boxed.set_instance (e);
-            mic_scroll_event (event_boxed);
+            var event_value = Value (typeof (Gdk.ScrollEvent));
+            event_value.set_instance (e);
+            mic_scroll_event (event_value);
             return Gdk.EVENT_STOP;
         });
 
@@ -64,9 +64,9 @@ public class Sound.DisplayWidget : Gtk.Box {
                 return Gdk.EVENT_PROPAGATE;
             }
 
-            var event_boxed = Value (typeof (Gdk.ScrollEvent));
-            event_boxed.set_instance (e);
-            volume_scroll_event (event_boxed);
+            var event_value = Value (typeof (Gdk.ScrollEvent));
+            event_value.set_instance (e);
+            volume_scroll_event (event_value);
             return Gdk.EVENT_STOP;
         });
 

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -23,8 +23,10 @@ public class Sound.DisplayWidget : Gtk.Box {
     public bool mic_muted { get; set; }
     public string icon_name { get; set; }
 
-    public signal void volume_scroll_event (Gdk.ScrollEvent e);
-    public signal void mic_scroll_event (Gdk.ScrollEvent e);
+    // HACK: Using Gdk.ScrollEvent instead of Value as the type of the parameter
+    // resulsts build error with valac 0.56.18
+    public signal void volume_scroll_event (Value event_boxed);
+    public signal void mic_scroll_event (Value event_boxed);
 
     construct {
         var volume_icon = new Gtk.Image () {
@@ -50,7 +52,9 @@ public class Sound.DisplayWidget : Gtk.Box {
                 return Gdk.EVENT_PROPAGATE;
             }
 
-            mic_scroll_event ((Gdk.ScrollEvent) e);
+            var event_boxed = Value (typeof (Gdk.ScrollEvent));
+            event_boxed.set_boxed (e);
+            mic_scroll_event (event_boxed);
             return Gdk.EVENT_STOP;
         });
 
@@ -60,7 +64,9 @@ public class Sound.DisplayWidget : Gtk.Box {
                 return Gdk.EVENT_PROPAGATE;
             }
 
-            volume_scroll_event ((Gdk.ScrollEvent) e);
+            var event_boxed = Value (typeof (Gdk.ScrollEvent));
+            event_boxed.set_boxed (e);
+            volume_scroll_event (event_boxed);
             return Gdk.EVENT_STOP;
         });
 

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -55,7 +55,7 @@ public class Sound.Widgets.Scale : Granite.Bin {
             }
 
             var event_boxed = Value (typeof (Gdk.ScrollEvent));
-            event_boxed.set_boxed (e);
+            event_boxed.set_instance (e);
             scroll_event (event_boxed);
 
             return Gdk.EVENT_STOP;

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -4,7 +4,9 @@
 */
 
 public class Sound.Widgets.Scale : Granite.Bin {
-    public signal void scroll_event (Gdk.ScrollEvent e);
+    // HACK: Using Gdk.ScrollEvent instead of Value as the type of the parameter
+    // resulsts build error with valac 0.56.18
+    public signal void scroll_event (Value event_boxed);
     public signal void slider_dropped ();
 
     public Gtk.Adjustment adjustment { get; construct; }
@@ -52,7 +54,9 @@ public class Sound.Widgets.Scale : Granite.Bin {
                 return Gdk.EVENT_PROPAGATE;
             }
 
-            scroll_event ((Gdk.ScrollEvent) e);
+            var event_boxed = Value (typeof (Gdk.ScrollEvent));
+            event_boxed.set_boxed (e);
+            scroll_event (event_boxed);
 
             return Gdk.EVENT_STOP;
         });

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -6,7 +6,7 @@
 public class Sound.Widgets.Scale : Granite.Bin {
     // HACK: Using Gdk.ScrollEvent instead of Value as the type of the parameter
     // resulsts build error with valac 0.56.18
-    public signal void scroll_event (Value event_boxed);
+    public signal void scroll_event (Value event_value);
     public signal void slider_dropped ();
 
     public Gtk.Adjustment adjustment { get; construct; }
@@ -54,9 +54,9 @@ public class Sound.Widgets.Scale : Granite.Bin {
                 return Gdk.EVENT_PROPAGATE;
             }
 
-            var event_boxed = Value (typeof (Gdk.ScrollEvent));
-            event_boxed.set_instance (e);
-            scroll_event (event_boxed);
+            var event_value = Value (typeof (Gdk.ScrollEvent));
+            event_value.set_instance (e);
+            scroll_event (event_value);
 
             return Gdk.EVENT_STOP;
         });

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -6,6 +6,7 @@
 public class Sound.Widgets.Scale : Granite.Bin {
     // HACK: Using Gdk.ScrollEvent instead of Value as the type of the parameter
     // resulsts build error with valac 0.56.18
+    // See https://gitlab.gnome.org/GNOME/vala/-/work_items/1671
     public signal void scroll_event (Value event_value);
     public signal void slider_dropped ();
 


### PR DESCRIPTION
Followup of #295

I suspect this is a bug of Vala. It tries to call `gdk_value_get_event()` which does not exist and fails to build with the following error message:

    ../src/Widgets/DisplayWidget.vala: In function ‘g_cclosure_user_marshal_VOID__GDK_EVENT’:
    ../src/Widgets/DisplayWidget.vala:18:19: error: implicit declaration of function ‘gdk_value_get_event’; did you mean ‘g_value_get_uint’? [-Wimplicit-function-declaration]
       18 | public class Sound.DisplayWidget : Gtk.Box {
          |                   ^~~~~~~~~~~~~~~~~~~
          |                   g_value_get_uint
    ../src/Widgets/DisplayWidget.vala:18:19: error: passing argument 2 of ‘callback’ makes pointer from integer without a cast [-Wint-conversion]
       18 | public class Sound.DisplayWidget : Gtk.Box {
          |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~
          |                   |
          |                   int

This commit resolves the above build error by wrapping Gdk.ScrollEvent with GLib.Value.