### PR TITLE
GTK 4: Fix missing player controls

### DIFF
--- a/src/Widgets/PlayerList.vala
+++ b/src/Widgets/PlayerList.vala
@@ -43,7 +43,6 @@ public class Sound.Widgets.PlayerList : Granite.Bin {
         });
 
         object_manager = new Services.ObjectManager ();
-        object_manager.bind_property ("has-object", this, "visible", GLib.BindingFlags.SYNC_CREATE);
 
         object_manager.media_player_added.connect ((media_player, name, icon) => {
             bluetooth_widget = new PlayerRow.bluetooth (media_player, name, icon);


### PR DESCRIPTION
Fix TODO in #295

<img width="329" height="203" alt="Screenshot_elementary-9-daily_2026-08-14_20:54:02" src="https://github.com/user-attachments/assets/56c81d4b-4002-4fd0-a4ca-b0ecba0111e0" />

This line has been here quite for a long time—since 27a982a5bb9107a475a90db44d96aa1e34e22317 (`src/Widgets/PlayerList.vala` was named `src/Widgets/MprisWidget.vala` at that time), where Bluetooth device support seems to be added. However, this has never been worked as _expected_ in GTK 3, since `show_all ()` is called against `default_widget` (which shows the player controls in the above screenshot) here:

https://github.com/elementary/wingpanel-indicator-sound/blob/16fb7bf5518f117bde433db92a0b8cb01fadb32f/src/Widgets/PlayerList.vala#L94

Now, `Gtk.Widget.show_all ()` has gone in GTK 4, and thus this line now works as _expected_, i.e. make the entire PlayerList widget invisible if `org.bluez` DBus service is not active for a reason like your device does not have a Bluetooth dongle.

```
Aug 14 21:13:38 elementary-9-daily io.elementary.wingpanel[13269]: Manager.vala:60: Error calling StartServiceByName for org.bluez: Failed to activate service 'org.bluez': timed out (service_start_timeout=25000ms)
```

The PlayerList widget shows player controls not only for Bluetooth devices, which ObjectManager handles, but also for MPRIS players. So, I removed this line since its' strange to make the entire widget invisible if no Bluetooth device is available.
