### PR TITLE
Fix compile error

### DIFF
--- a/src/Services/ShellKeyGrabber.vala
+++ b/src/Services/ShellKeyGrabber.vala
@@ -41,7 +41,7 @@ public struct Sound.Accelerator {
 
 [DBus (name = "org.gnome.Shell")]
 public interface Sound.ShellKeyGrabber : GLib.Object {
-    public abstract signal void accelerator_activated (uint action, GLib.HashTable<string, GLib.Variant> parameters_dict);
+    public signal void accelerator_activated (uint action, GLib.HashTable<string, GLib.Variant> parameters_dict);
 
     public abstract uint grab_accelerator (string accelerator, ActionMode mode_flags, Meta.KeyBindingFlags grab_flags) throws GLib.DBusError, GLib.IOError;
     public abstract uint[] grab_accelerators (Accelerator[] accelerators) throws GLib.DBusError, GLib.IOError;


### PR DESCRIPTION
```
../src/Services/ShellKeyGrabber.vala:44:12-44:19: error: `abstract' modifier not applicable on signals
   44 |     public abstract signal void accelerator_activated (uint action, GLib.HashTable<string, GLib.Variant> parameters_dict);
      |            ^~~~~~~~                                                                                                       
Compilation failed: 1 error(s), 0 warning(s)
```